### PR TITLE
workspaces WIP

### DIFF
--- a/pkgs/applications/networking/remote/aws-workspaces/default.nix
+++ b/pkgs/applications/networking/remote/aws-workspaces/default.nix
@@ -1,6 +1,7 @@
 { stdenv, lib
 , makeWrapper, dpkg, fetchurl, autoPatchelfHook
-, curl, libkrb5, lttng-ust, libpulseaudio, gtk3, openssl, icu70, webkitgtk, librsvg, gdk-pixbuf, libsoup, glib-networking, graphicsmagick_q16, libva, libusb1, hiredis, pcsclite, jbigkit, libvdpau
+, curl, libkrb5, lttng-ust, libpulseaudio, gtk3, openssl, icu70, webkitgtk, librsvg, gdk-pixbuf, libsoup, glib-networking, graphicsmagick_q16, libva, libusb1, hiredis, pcsclite, jbigkit, libtiff, libvdpau
+, ffmpeg_6, lmdb, protobufc, zlib
 }:
 
 stdenv.mkDerivation rec {
@@ -46,19 +47,22 @@ stdenv.mkDerivation rec {
     pcsclite
     jbigkit
     libvdpau
+    libtiff
+    ffmpeg_6.lib
+    lmdb
+    protobufc
+    zlib
   ];
 
   unpackPhase = ''
     ${dpkg}/bin/dpkg -x $src $out
-  '';
-
-  preFixup = ''
-    patchelf --replace-needed libjbig.so.0 libjbig.so $out/bin/workspacesclient/dcv/libtiff.so.6
+    rm -rf $out/usr/lib/x86_64-linux-gnu/workspacesclient/dcv/g*
+    rm -rf $out/usr/lib/x86_64-linux-gnu/workspacesclient/dcv/lib[acefghjlnoptz]*
+    ls -alR $out
   '';
 
   installPhase = ''
     mkdir -p $out/bin $out/lib
-    mv $out/usr/lib/x86_64-linux-gnu/* $out/lib
     rm -rf $out/opt
 
     wrapProgram $out/usr/bin/workspacesclient \
@@ -66,7 +70,7 @@ stdenv.mkDerivation rec {
       --set GDK_PIXBUF_MODULE_FILE "${librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" \
       --set GIO_EXTRA_MODULES "${glib-networking.out}/lib/gio/modules"
 
-    mv $out/lib/workspacesclient $out/bin
+    mv $out/usr/bin/workspacesclient $out/bin/workspacesclient
   '';
 
   meta = with lib; {
@@ -76,5 +80,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ]; # TODO Mac support
     maintainers = with maintainers; [ mausch dylanmtaylor ];
+    mainProgram = "workspacesclient";
   };
 }


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/251976

My approach in cases like this is to replace as many included libs as possible with nix ones.
I think all libs can be replaced here except for [libdcv which is proprietary thing from AWS](https://aws.amazon.com/hpc/dcv/).

Currently this passes the patchelf phase and build but coredumps at startup.
I'm sending this PR in case you want to pick it up.

More libs still need to be replaced:

/usr/lib/x86_64-linux-gnu/workspacesclient/dcv:

librsvg-2.so.2
libsasl2.so.3
libsoup-3.0.so.0
libvpx.so.8
libwayland-client.so.0
libwayland-cursor.so.0
libwayland-egl.so.1
sasl2


